### PR TITLE
🔧 修復模組導入問題

### DIFF
--- a/bot/api/auth.py
+++ b/bot/api/auth.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-import jwt
+from jose import jwt
 from fastapi import Depends, HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel

--- a/bot/main.py
+++ b/bot/main.py
@@ -14,6 +14,9 @@ import signal
 import sys
 import time
 
+# 添加專案根目錄到 Python 路徑
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv


### PR DESCRIPTION
• 修復 JWT 模組問題：使用 python-jose 代替 PyJWT
• 修復 shared.local_cache_manager 模組路徑問題
• 添加專案根目錄到 Python 路徑

解決的錯誤：
- ModuleNotFoundError: No module named 'jwt'
- No module named 'shared.local_cache_manager'

🤖 Generated with [Claude Code](https://claude.ai/code)