### PR TITLE
🔧 修復部署工作流程：移除對不存在腳本的依賴

### DIFF
--- a/.github/workflows/deploy-to-ptero.yml
+++ b/.github/workflows/deploy-to-ptero.yml
@@ -112,8 +112,20 @@ jobs:
     - name: 🛡️ 執行生產檔案合規檢查
       run: |
         echo "🔍 執行生產檔案合規檢查..."
-        chmod +x .github/scripts/production-compliance-check.sh
-        .github/scripts/production-compliance-check.sh
+        
+        # 檢查是否存在開發文件
+        echo "檢查開發文件..."
+        if [ -d "tests/" ] || [ -f "pytest.ini" ] || [ -d "docs/development/" ]; then
+          echo "❌ 發現開發文件，不符合生產要求"
+          exit 1
+        fi
+        
+        # 檢查核心文件存在
+        echo "檢查核心文件..."
+        if [ ! -f "bot/main.py" ] || [ ! -f "shared/config.py" ]; then
+          echo "❌ 缺少核心文件"
+          exit 1
+        fi
         
         echo "✅ 生產合規檢查通過"
 


### PR DESCRIPTION
## 問題描述
Deploy to Ptero 工作流程失敗，錯誤訊息：
```
chmod: cannot access '.github/scripts/production-compliance-check.sh': No such file or directory
```

## 根本原因
工作流程嘗試執行已在主分支清理中移除的外部腳本檔案。

## 解決方案
將外部腳本調用替換為內聯 bash 檢查：

### 修改內容：
- ✅ 移除 `chmod +x .github/scripts/production-compliance-check.sh`
- ✅ 移除 `./.github/scripts/production-compliance-check.sh`
- ✅ 添加內聯開發文件檢查
- ✅ 添加核心文件完整性驗證

### 檢查邏輯：
1. **開發文件檢查**: 確認 tests/, pytest.ini, docs/development/ 等已移除
2. **核心文件驗證**: 確認 bot/main.py, shared/config.py 等存在

## 測試
- [x] 本地語法檢查通過
- [ ] 等待 CI 驗證

🤖 Generated with [Claude Code](https://claude.ai/code)