### PR TITLE
🔧 全分支修復：啟動器路徑自動檢測

### DIFF
--- a/start.py
+++ b/start.py
@@ -14,7 +14,17 @@ from pathlib import Path
 class PotatoBotStarter:
     def __init__(self):
         self.root_dir = Path(__file__).parent
-        self.bot_file = self.root_dir / "bot" / "main.py"
+        # 智能尋找主程式位置
+        potential_bot_files = [
+            self.root_dir / "src" / "potato_bot" / "main.py",  # 新架構
+            self.root_dir / "bot" / "main.py",  # 舊架構
+        ]
+        self.bot_file = None
+        for bot_file in potential_bot_files:
+            if bot_file.exists():
+                self.bot_file = bot_file
+                break
+        
         self.env_file = self.root_dir / ".env"
         self.env_example = self.root_dir / ".env.example"
 
@@ -103,19 +113,19 @@ class PotatoBotStarter:
                 elif package == "aiomysql":
                     pass
 
-                    print(f"✅ aiomysql")
+                    print("✅ aiomysql")
                 elif package == "python-dotenv":
                     pass
 
-                    print(f"✅ python-dotenv")
+                    print("✅ python-dotenv")
                 elif package == "fastapi":
                     pass
 
-                    print(f"✅ fastapi")
+                    print("✅ fastapi")
                 elif package == "uvicorn":
                     pass
 
-                    print(f"✅ uvicorn")
+                    print("✅ uvicorn")
             except ImportError:
                 print(f"❌ {package}")
                 missing_packages.append(package)
@@ -167,18 +177,19 @@ class PotatoBotStarter:
 
     def check_bot_file(self):
         """檢查 Bot 主程式"""
-        print(f"\n🤖 檢查 Bot 主程式: {self.bot_file}")
-
-        if not self.bot_file.exists():
-            print("❌ 未找到 bot/main.py")
+        if self.bot_file is None:
+            print("\n🤖 檢查 Bot 主程式: 尋找中...")
+            print("❌ 未找到 Bot 主程式")
+            print("   預期位置: src/potato_bot/main.py 或 bot/main.py")
             return False
-
+        
+        print(f"\n🤖 檢查 Bot 主程式: {self.bot_file}")
         print("✅ Bot 主程式存在")
         return True
 
     def show_system_info(self):
         """顯示系統資訊"""
-        print(f"\n💻 系統資訊:")
+        print("\n💻 系統資訊:")
         print(f"   作業系統: {platform.system()} {platform.release()}")
         print(f"   架構: {platform.machine()}")
         print(f"   Python: {platform.python_version()}")


### PR DESCRIPTION
## 問題描述
所有分支都存在相同的問題：start.py 硬編碼尋找 `bot/main.py`，但實際主程式位於 `src/potato_bot/main.py`。

### 錯誤訊息：
```
🤖 檢查 Bot 主程式: /path/to/bot/main.py
❌ 未找到 bot/main.py  
❌ Bot 主程式檢查失敗
```

## 🔍 根本原因
專案架構重構後，主程式路徑從 `bot/main.py` 遷移到 `src/potato_bot/main.py`，但啟動器未更新路徑檢測邏輯。

## ✅ 解決方案

### 智能路徑檢測
```python
# 舊版本 - 硬編碼路徑
self.bot_file = self.root_dir / "bot" / "main.py"

# 新版本 - 智能檢測
potential_bot_files = [
    self.root_dir / "src" / "potato_bot" / "main.py",  # 新架構
    self.root_dir / "bot" / "main.py",  # 舊架構  
]
self.bot_file = None
for bot_file in potential_bot_files:
    if bot_file.exists():
        self.bot_file = bot_file
        break
```

### 改善錯誤處理
- ✅ 檢測失敗時顯示所有預期位置
- ✅ 向後相容支援不同專案結構
- ✅ 清晰的診斷訊息

## 📊 修復範圍

### 影響的分支：
- ✅ **ptero** - 已修復並測試
- ⏳ **main** - 此 PR 修復
- ⏳ **develop** - 需要同步修復

### 測試結果：
```
找到的 bot 主程式: /root/projects/potato/src/potato_bot/main.py
檢查路徑 src/potato_bot/main.py: 存在 ✅
檢查路徑 bot/main.py: 不存在 ❌
```

## 🎯 修復效果

### 修復前：
```
❌ 未找到 bot/main.py
❌ Bot 主程式檢查失敗
```

### 修復後：
```  
✅ Bot 主程式: /path/to/src/potato_bot/main.py
✅ Bot 主程式存在
```

## ⚠️ 重要性
這個修復對所有分支都至關重要，確保：
- 🚀 啟動器能正確找到主程式
- 📦 支援不同的專案架構
- 🔄 向後相容保證
- 🎯 清晰的錯誤診斷

🤖 Generated with [Claude Code](https://claude.ai/code)