### PR TITLE
🔧 修復 GitHub Actions 推送權限問題

### DIFF
--- a/.github/workflows/auto-sync-ptero.yml
+++ b/.github/workflows/auto-sync-ptero.yml
@@ -17,6 +17,12 @@ on:
         type: string
         default: ''
 
+permissions:
+  contents: write
+  actions: read
+  checks: read
+  pull-requests: read
+
 env:
   PTERO_BRANCH: ptero
   MAIN_BRANCH: main


### PR DESCRIPTION
## 🎯 問題描述
修復 auto-sync-ptero.yml 工作流程中的權限問題：
- **錯誤**: `Permission to Craig-0219/potato.git denied to github-actions[bot]`
- **原因**: 工作流程缺少必要的權限配置，預設 GITHUB_TOKEN 權限不足

## 🔧 修復內容

### 添加 GitHub Actions 權限配置
```yaml
permissions:
  contents: write      # 允許推送到分支
  actions: read        # 讀取Actions狀態  
  checks: read         # 讀取檢查狀態
  pull-requests: read  # 讀取PR狀態
```

### 解決的問題
- ✅ 允許 GitHub Actions bot 推送到 ptero 分支
- ✅ 確保工作流程有足夠權限執行同步操作
- ✅ 維持最小權限原則，僅授予必要權限

## 📊 測試驗證
- ✅ YAML 語法驗證通過
- ✅ 權限配置符合 GitHub Actions 規範
- ✅ 遵循最小權限原則

## 🎯 預期效果
修復後 main → ptero 自動同步工作流程將能夠：
1. ✅ 成功檢測變更 (已修復)
2. ✅ 執行智能合併同步
3. ✅ 推送變更到 ptero 分支 (本次修復)
4. ✅ 完成完整的自動同步流程

🤖 Generated with [Claude Code](https://claude.ai/code)